### PR TITLE
BUG: Fix subfolder custom name anchoring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,10 @@ jobs:
         run: |
           uv pip install ruff
 
-      - name: Run Ruff format & Check
+      - name: Run Ruff format
         run: ruff format --check .
 
-      - name: Run flake8
+      - name: Run ruff check
         run: ruff check
 
   type-check:
@@ -36,7 +36,7 @@ jobs:
     name: Type-check (mypy)
     strategy:
       matrix:
-        python-version: [3.7, 3.13]
+        python-version: [3.7, 3.14]
     steps:
       - uses: actions/checkout@v4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Development Version
+- Subfolder attributes with a pre-assigned `Folder` value (used to give a custom
+  directory name) are now correctly anchored under the parent folder (#13).
+- `FolderLike` is now an Abstract Base Class (ABC) instead of a `typing.Protocol`.
+  Subclasses must implement `from_path`, `__fspath__`, `get_subfolder`, and `create`.
+- Now raise a `TypeError` when a `FolderLike`-annotated attribute is assigned a `Path` value.
+- Now raise a `TypeError` when `FolderPartition` is constructed without an explicit generic type.
+
 ## Version 0.3 (August 23, 2025)
 - Prevent str annotation to avoid ambiguity (#10)
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -1106,8 +1106,8 @@ packages:
   timestamp: 1751135714659
 - pypi: .\
   name: static-folders
-  version: 0.2.0
-  sha256: 1db1b84539648aac264ad594fec0289af4e76e043300951cf7f37977020378fa
+  version: 0.3.0
+  sha256: 1b62e52405ac0b081660af21cb9404afdf658b930dd859995e7328d6842d231f
   requires_dist:
   - attrs>=24.2.0
   - typing-extensions>=4.7.1 ; python_full_version < '3.13'

--- a/pixi.lock
+++ b/pixi.lock
@@ -1107,7 +1107,7 @@ packages:
 - pypi: .\
   name: static-folders
   version: 0.3.0
-  sha256: 1b62e52405ac0b081660af21cb9404afdf658b930dd859995e7328d6842d231f
+  sha256: 46a58f98901262827b28e2489651a9cc7e92070bf17a26d012e7c5cf6668d243
   requires_dist:
   - attrs>=24.2.0
   - typing-extensions>=4.7.1 ; python_full_version < '3.13'

--- a/pixi.lock
+++ b/pixi.lock
@@ -31,7 +31,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd72426e_102.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
       - pypi: https://files.pythonhosted.org/packages/69/e0/552843e0d356fbb5256d21449fa957fa4eff3bbc135a74a691ee70c7c5da/typing_extensions-4.14.0-py3-none-any.whl
-      - pypi: .\
+      - pypi: ./
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-25.3.0-pyh71513ae_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
@@ -51,7 +51,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h41ae7f8_26.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_26.conda
       - pypi: https://files.pythonhosted.org/packages/69/e0/552843e0d356fbb5256d21449fa957fa4eff3bbc135a74a691ee70c7c5da/typing_extensions-4.14.0-py3-none-any.whl
-      - pypi: .\
+      - pypi: ./
   latest:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -95,7 +95,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.14.0-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
-      - pypi: .\
+      - pypi: ./
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-25.3.0-pyh71513ae_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
@@ -127,7 +127,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h41ae7f8_26.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_26.conda
-      - pypi: .\
+      - pypi: ./
   min:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -177,7 +177,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-gpl-tools-5.8.1-hbcc6ac9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-tools-5.8.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.15.0-pyhd8ed1ab_0.conda
-      - pypi: .\
+      - pypi: ./
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.6.15-h4c7d964_0.conda
@@ -206,7 +206,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_26.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.44.35208-h38c0c73_26.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.15.0-pyhd8ed1ab_0.conda
-      - pypi: .\
+      - pypi: ./
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
   sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
@@ -1104,10 +1104,10 @@ packages:
   purls: []
   size: 400821
   timestamp: 1751135714659
-- pypi: .\
+- pypi: ./
   name: static-folders
   version: 0.3.0
-  sha256: 46a58f98901262827b28e2489651a9cc7e92070bf17a26d012e7c5cf6668d243
+  sha256: 63a4aaa4383e0641f49a084956dcfccd06ba224d9b4221152c3a12500a21f809
   requires_dist:
   - attrs>=24.2.0
   - typing-extensions>=4.7.1 ; python_full_version < '3.13'

--- a/pixi.lock
+++ b/pixi.lock
@@ -1107,7 +1107,7 @@ packages:
 - pypi: ./
   name: static-folders
   version: 0.3.0
-  sha256: 63a4aaa4383e0641f49a084956dcfccd06ba224d9b4221152c3a12500a21f809
+  sha256: 41e65b3b2383719357d9f7c669bc69c3e5ceb408d7000623c8821b51ae2bb13c
   requires_dist:
   - attrs>=24.2.0
   - typing-extensions>=4.7.1 ; python_full_version < '3.13'

--- a/pixi.toml
+++ b/pixi.toml
@@ -7,8 +7,8 @@ platforms = ["win-64", "linux-64"]
 version = "0.1.0"
 
 [tasks]
-format = "uvx ruff format"
-lint = "uvx ruff check"
+format = "uvx ruff@latest format"
+lint = "uvx ruff@latest check"
 type_check = "uvx --with . --with attrs --with pytest mypy ."
 # SyntaxError: Non-UTF-8 code starting with '\xe8' in Scripts\mypy.exe
 #type_check_min = "uvx --python 3.7 --with . --with attrs mypy python -m mypy ."

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,4 +1,4 @@
-[project]
+[workspace]
 authors = ["Matt Richards <mrichards7@outlook.com.au>"]
 channels = ["conda-forge"]
 description = "Modelling Static folder structures for python applications"

--- a/pixi.toml
+++ b/pixi.toml
@@ -30,7 +30,7 @@ static_folders = { path = ".", editable = true}
 
 [feature.py37.dependencies]
 python = "3.7.*"
-typing-extensions = "==4.7.1"
+typing-extensions = "*"
 
 [feature.py37.tasks]
 test = "pytest -rP ."

--- a/pixi.toml
+++ b/pixi.toml
@@ -9,11 +9,14 @@ version = "0.1.0"
 [tasks]
 format = "uvx ruff@latest format"
 lint = "uvx ruff@latest check"
+ruff-fix = "uvx ruff@latest check --fix"
 type_check = "uvx --with . --with attrs --with pytest mypy ."
 # SyntaxError: Non-UTF-8 code starting with '\xe8' in Scripts\mypy.exe
 #type_check_min = "uvx --python 3.7 --with . --with attrs mypy python -m mypy ."
 # TODO do with depends-on
-check_all = [{ task = "format" }, { task = "lint" }, { task = "type_check" }]
+check-all = [{ task = "format" }, { task = "lint" }, { task = "type_check" }]
+
+
 ci_all_checks = {cmd = "pixi run format; pixi run lint; pixi run type_check"}
 #ci_tests = {cmd = "pixi run format; pixi run lint; pixi run type_check"}
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -30,7 +30,7 @@ static_folders = { path = ".", editable = true}
 
 [feature.py37.dependencies]
 python = "3.7.*"
-typing-extensions = "*"
+typing-extensions = "==4.7.1"
 
 [feature.py37.tasks]
 test = "pytest -rP ."

--- a/pixi.toml
+++ b/pixi.toml
@@ -13,6 +13,7 @@ type_check = "uvx --with . --with attrs --with pytest mypy ."
 # SyntaxError: Non-UTF-8 code starting with '\xe8' in Scripts\mypy.exe
 #type_check_min = "uvx --python 3.7 --with . --with attrs mypy python -m mypy ."
 # TODO do with depends-on
+check_all = [{ task = "format" }, { task = "lint" }, { task = "type_check" }]
 ci_all_checks = {cmd = "pixi run format; pixi run lint; pixi run type_check"}
 #ci_tests = {cmd = "pixi run format; pixi run lint; pixi run type_check"}
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -13,12 +13,10 @@ ruff-fix = "uvx ruff@latest check --fix"
 type_check = "uvx --with . --with attrs --with pytest mypy ."
 # SyntaxError: Non-UTF-8 code starting with '\xe8' in Scripts\mypy.exe
 #type_check_min = "uvx --python 3.7 --with . --with attrs mypy python -m mypy ."
-# TODO do with depends-on
-check-all = [{ task = "format" }, { task = "lint" }, { task = "type_check" }]
+check-all = [{ task = "format" }, { task = "lint" }, { task = "type_check" }, { task = "type_check_min" }]
+check_all = [{ task = "check-all" }]
+fix = [{ task = "ruff-fix" }]
 
-
-ci_all_checks = {cmd = "pixi run format; pixi run lint; pixi run type_check"}
-#ci_tests = {cmd = "pixi run format; pixi run lint; pixi run type_check"}
 
 
 
@@ -34,7 +32,10 @@ typing-extensions = "==4.7.1"
 
 [feature.py37.tasks]
 test = "pytest -rP ."
-type_check_min = "mypy ."
+# specific incantation to get this to work - uv variant works
+type_check_min = "uv run --no-project --python 3.7 --with 'typing-extensions==4.7.1' --with attrs --with mypy --with . python -m mypy ."
+# just doesn't work, unclear why
+#type_check_min_pixi = "python -m mypy ."
 
 [feature.py313.dependencies]
 python = "3.13.*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,8 @@ typing-modules = []
 
 
 select = [
+    # isort
+    "I",
   # pyflakes
   "F",
   # pycodestyle

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,9 +36,14 @@ dev = [
 line-length = 120
 target-version = "py37"
 
+
+[tool.ruff.format]
+docstring-code-format = true
+
 [tool.ruff.lint]
 unfixable = []
 typing-modules = []
+
 
 select = [
   # pyflakes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,5 +198,6 @@ ignore = [
 "test/*" = [
   "S101", # assert is fine with pytest tests
   "INP001", # tests aren't proper packages to be imported, okay to ignore
+   "FBT001", # bool positionals are needed for bool fixtures
 ]
 

--- a/src/static_folders/__init__.py
+++ b/src/static_folders/__init__.py
@@ -1,4 +1,4 @@
-from .folder import Folder, FolderName
+from .folder import Folder, _FolderName, custom_name
 from .partitioned_folder import FolderPartition, EnumeratedFolderPartition
 
-__all__ = ["EnumeratedFolderPartition", "Folder", "FolderName", "FolderPartition"]
+__all__ = ["EnumeratedFolderPartition", "Folder", "FolderPartition", "_FolderName", "custom_name"]

--- a/src/static_folders/__init__.py
+++ b/src/static_folders/__init__.py
@@ -1,4 +1,4 @@
-from .folder import Folder
+from .folder import Folder, FolderName
 from .partitioned_folder import FolderPartition, EnumeratedFolderPartition
 
-__all__ = ["EnumeratedFolderPartition", "Folder", "FolderPartition"]
+__all__ = ["EnumeratedFolderPartition", "Folder", "FolderName", "FolderPartition"]

--- a/src/static_folders/__init__.py
+++ b/src/static_folders/__init__.py
@@ -1,4 +1,4 @@
-from .folder import Folder, _FolderName, custom_name
+from .folder import Folder
 from .partitioned_folder import FolderPartition, EnumeratedFolderPartition
 
-__all__ = ["EnumeratedFolderPartition", "Folder", "FolderPartition", "_FolderName", "custom_name"]
+__all__ = ["EnumeratedFolderPartition", "Folder", "FolderPartition"]

--- a/src/static_folders/__init__.py
+++ b/src/static_folders/__init__.py
@@ -1,4 +1,4 @@
 from .folder import Folder
-from .partitioned_folder import FolderPartition, EnumeratedFolderPartition
+from .partitioned_folder import EnumeratedFolderPartition, FolderPartition
 
 __all__ = ["EnumeratedFolderPartition", "Folder", "FolderPartition"]

--- a/src/static_folders/folder.py
+++ b/src/static_folders/folder.py
@@ -5,7 +5,7 @@ import os
 import sys
 import typing
 from pathlib import Path, PureWindowsPath, PurePosixPath
-from typing import Sequence, Any, Callable, TypeVar, ClassVar, Type
+from typing import Sequence, Any, Callable, TypeVar, ClassVar, Type, overload
 
 from attrs import define, field, Factory
 from typing_extensions import Self
@@ -22,11 +22,29 @@ U = TypeVar("U", bound="Folder")
 PathLike = typing.Union[str, Path]
 T = TypeVar("T", bound="Folder")
 
-BasePurePath = PureWindowsPath if os.name == "nt" else PurePosixPath
+V = TypeVar("V")
+
+if sys.platform == "win32":
+
+    class _FolderName(PureWindowsPath):
+        """TODO this subclassing might be a bad idea"""
+else:
+
+    class FolderName(PurePosixPath):
+        """TODO this subclassing might be a bad idea"""
 
 
-class FolderName(BasePurePath):
-    """TODO this subclassing might be a bad idea"""
+@overload
+def custom_name(name: str, annotation_type: None = ...) -> Folder: ...
+
+
+@overload
+def custom_name(name: str, annotation_type: Type[U] = ...) -> U: ...
+
+
+def custom_name(name: str, annotation_type: Type[U] | None = None) -> U | Folder:
+    # We are lying to the type system here, and assuming users don't use this
+    return _FolderName(name)  # type:ignore[return-value]
 
 
 # def name(value):
@@ -115,9 +133,10 @@ class Folder(FolderLike):
             if isinstance(annotation, type):
                 if issubclass(annotation, Folder):  # i.e. attribute foo: Folder - a class constructor
                     value = getattr(self, attrib_name, None)
+                    folder_name = None
                     if value is None:  # check default wasn't given
                         folder_name = attrib_name
-                    elif isinstance(value, FolderName):
+                    elif isinstance(value, _FolderName):
                         folder_name = value.name
                     elif isinstance(value, Folder):
                         msg = (
@@ -128,14 +147,26 @@ class Folder(FolderLike):
                             f"migrate to {attrib_name}: {annotation} = FolderName(...) "
                         )
                         raise TypeError(msg)
+                    elif isinstance(value, Path):
+                        # TODO, if we're doing all this at runtime, do we get it at type checking time?
+                        # and if not, does that defeat the purpose of this being staticly typed.
+                        msg = (
+                            f"Annotating an attribute with a Folder type and a Path value is ambiguous "
+                            f"and not supported (got {attrib_name}: {annotation} = {value}). "
+                            f"If you intended to declare a subfolder with a custom folder name, "
+                            f"you should update the Path value to a FolderName value instead.\n"
+                            f"If you intended to declare a file within the folder, you should update the "
+                            f"Folder annotation to be a Path instead."
+                        )
+                        raise TypeError(msg)
                     else:
                         pass  # subclasses or lambda come through this passage
                         # print("pre-existing thing", value)
+                    if folder_name is not None:
+                        value = annotation(self.location / folder_name)
+                        setattr(self, attrib_name, value)
 
-                    value = annotation(self.location / folder_name)
-                    setattr(self, attrib_name, value)
-
-                    self._child_folders.append(value)
+                        self._child_folders.append(value)
                     # else: # extract path from given default
                     #     setattr(self, attrib_name, annotation(self.location / os.fspath(value)))
 

--- a/src/static_folders/folder.py
+++ b/src/static_folders/folder.py
@@ -4,7 +4,7 @@ import inspect
 import os
 import sys
 import typing
-from pathlib import Path
+from pathlib import Path, PureWindowsPath, PurePosixPath
 from typing import Sequence, Any, Callable, TypeVar, ClassVar, Type
 
 from attrs import define, field, Factory
@@ -21,6 +21,20 @@ U = TypeVar("U", bound="Folder")
 
 PathLike = typing.Union[str, Path]
 T = TypeVar("T", bound="Folder")
+
+BasePurePath = PureWindowsPath if os.name == "nt" else PurePosixPath
+
+
+class FolderName(BasePurePath):
+    """TODO this subclassing might be a bad idea"""
+
+
+# def name(value):
+#     """First draft value to distinguish folder directory overrides.
+#
+#     # TODO should we just have FolderName / FileName classes for consistency?
+#     """
+#     return CustomFolderName(value)
 
 
 def _get_annotations(obj: Callable[..., object] | type[Any] | ModuleType) -> dict[str, object]:
@@ -68,7 +82,7 @@ class Folder(FolderLike):
     def __fspath__(self) -> str:
         return str(self.location)
 
-    def __attrs_post_init__(self) -> None:
+    def __attrs_post_init__(self) -> None:  # noqa: PLR0912
         self.location = Path(os.fspath(self._raw_location))
         cls = type(self)
         # custom support for annotations which are sub-types of Folder, or Path
@@ -102,8 +116,25 @@ class Folder(FolderLike):
                 if issubclass(annotation, Folder):  # i.e. attribute foo: Folder - a class constructor
                     value = getattr(self, attrib_name, None)
                     if value is None:  # check default wasn't given
-                        value = annotation(self.location / attrib_name)
-                        setattr(self, attrib_name, value)
+                        folder_name = attrib_name
+                    elif isinstance(value, FolderName):
+                        folder_name = value.name
+                    elif isinstance(value, Folder):
+                        msg = (
+                            f"Providing a folder annotation with a folder value "
+                            f"({attrib_name}: {annotation} = {value}) is deprecated, "
+                            "behaviour was not sound with respect to child file paths. If the intention"
+                            "was to specify a custom folder name, you should "
+                            f"migrate to {attrib_name}: {annotation} = FolderName(...) "
+                        )
+                        raise TypeError(msg)
+                    else:
+                        pass  # subclasses or lambda come through this passage
+                        # print("pre-existing thing", value)
+
+                    value = annotation(self.location / folder_name)
+                    setattr(self, attrib_name, value)
+
                     self._child_folders.append(value)
                     # else: # extract path from given default
                     #     setattr(self, attrib_name, annotation(self.location / os.fspath(value)))

--- a/src/static_folders/folder.py
+++ b/src/static_folders/folder.py
@@ -90,7 +90,11 @@ class Folder(FolderLike):
         "_raw_location",
         "_child_folders",
     ]
-    _child_folders: list[Folder] = field(init=False, default=Factory(list))
+    _child_folders: list[FolderLike] = field(init=False, default=Factory(list))
+
+    @classmethod
+    def from_path(cls, path: Path) -> Folder:
+        return cls(path)
 
     @classmethod
     def from_string(cls, path: str) -> Self:
@@ -163,7 +167,7 @@ class Folder(FolderLike):
                         pass  # subclasses or lambda come through this passage
                         # print("pre-existing thing", value)
                     if folder_name is not None:
-                        value = annotation(self.location / folder_name)
+                        value = annotation.from_path(self.location / folder_name)
                         setattr(self, attrib_name, value)
 
                         self._child_folders.append(value)

--- a/src/static_folders/folder.py
+++ b/src/static_folders/folder.py
@@ -5,9 +5,9 @@ import os
 import sys
 import typing
 from pathlib import Path
-from typing import Sequence, Any, Callable, TypeVar, ClassVar, Type
+from typing import Any, Callable, ClassVar, Sequence, Type, TypeVar
 
-from attrs import define, field, Factory
+from attrs import Factory, define, field
 from typing_extensions import Self
 
 from static_folders.folder_interface import FolderLike

--- a/src/static_folders/folder.py
+++ b/src/static_folders/folder.py
@@ -131,7 +131,14 @@ class Folder(FolderLike):
                         pass  # subclasses or lambda come through this passage
                         # print("pre-existing thing", value)
                     if folder_name is not None:
-                        value = annotation.from_path(self.location / folder_name)
+                        try:
+                            value = annotation.from_path(self.location / folder_name)
+                        except TypeError as e:
+                            msg = (
+                                f"Building Class {type(self).__name__} failed on constructing attribute:\n"
+                                f"'{attrib_name}: {annotation} = {value!r}' with attached error"
+                            )
+                            raise TypeError(msg) from e
                         setattr(self, attrib_name, value)
 
                         self._child_folders.append(value)

--- a/src/static_folders/folder.py
+++ b/src/static_folders/folder.py
@@ -4,8 +4,8 @@ import inspect
 import os
 import sys
 import typing
-from pathlib import Path, PureWindowsPath, PurePosixPath
-from typing import Sequence, Any, Callable, TypeVar, ClassVar, Type, overload
+from pathlib import Path
+from typing import Sequence, Any, Callable, TypeVar, ClassVar, Type
 
 from attrs import define, field, Factory
 from typing_extensions import Self
@@ -23,30 +23,6 @@ PathLike = typing.Union[str, Path]
 T = TypeVar("T", bound="Folder")
 
 V = TypeVar("V")
-
-if sys.platform == "win32":
-
-    class _FolderName(PureWindowsPath):
-        """TODO this subclassing might be a bad idea"""
-else:
-
-    class FolderName(PurePosixPath):
-        """TODO this subclassing might be a bad idea"""
-
-
-@overload
-def custom_name(name: str, annotation_type: None = ...) -> Folder: ...
-
-
-@overload
-def custom_name(name: str, annotation_type: Type[U] = ...) -> U: ...
-
-
-def custom_name(name: str, annotation_type: Type[U] | None = None) -> U | Folder:
-    # We are lying to the type system here, and assuming users don't use this in a context where they could
-    # see the return value. We only use the distinct type here as a marker to tell folders from files
-    # TODO should this be implemented via Annotated[str, "custom_folder_name"] instead?
-    return _FolderName(name)  # type:ignore[return-value]
 
 
 def _get_annotations(obj: Callable[..., object] | type[Any] | ModuleType) -> dict[str, object]:
@@ -125,36 +101,30 @@ class Folder(FolderLike):
             )
             raise TypeError(msg)
 
+        # resolve all the child attributes from annotations into instance objects
         for attrib_name, annotation in annotations.items():
             if attrib_name in self._reserved_attributes:
                 continue
             if isinstance(annotation, type):
-                if issubclass(annotation, FolderLike):  # i.e. attribute foo: Folder - a class constructor
+                if issubclass(annotation, FolderLike):  # e.g. `foo: Folder`
                     value = getattr(self, attrib_name, None)
                     folder_name = None
                     if value is None:  # check default wasn't given
                         folder_name = attrib_name
-                    elif isinstance(value, _FolderName):
-                        folder_name = value.name
-                    elif isinstance(value, FolderLike):
+                    elif isinstance(value, FolderLike):  # `foo: Folder = Folder("bar")` -> foo / "bar"
+                        folder_name = value.location.name
+                    elif isinstance(value, Path):  # `foo: Folder = Path("bar")`
+                        # This is not permitted by the type system, but is an easy typo someone could make
+                        # which would lead to confusing behaviour - the path wouldn't be "seen" at all.
                         msg = (
-                            f"Providing a FolderLike annotation with a FolderLike value "
-                            f"({attrib_name}: {annotation} = {value}) is deprecated, "
-                            "behaviour was not sound with respect to child file paths. If the intention "
-                            "was to specify a custom folder name, you should "
-                            f"migrate to {attrib_name}: {annotation} = sf.custom_name(...) "
-                        )
-                        raise TypeError(msg)
-                    elif isinstance(value, Path):
-                        # TODO, if we're doing all this at runtime, do we get it at type checking time?
-                        # and if not, does that defeat the purpose of this being staticly typed.
-                        msg = (
-                            f"Annotating an attribute with a FolderLike type and a Path value is ambiguous "
-                            f"and not supported (got {attrib_name}: {annotation} = {value}). "
+                            f"Annotating an attribute with a FolderLike type and a Path value is incorrect "
+                            f"and not supported. For class `{type(self).__name__}` got:\n"
+                            f"'{attrib_name}: {annotation} = {value!r}'\n"
                             f"If you intended to declare a subfolder with a custom folder name, "
-                            f"you should update the Path value to a sf.custom_name(...) value instead.\n"
-                            f"If you intended to declare a file within the folder, you should update the "
-                            f"FolderLike annotation to be a Path instead."
+                            f"you should use `{attrib_name}: FolderLike: FolderLike(name)` instead.\n"
+                            f"If you intended to declare a file within the folder, you should use"
+                            f" `{attrib_name}: Path: Path(name)` "
+                            f"instead."
                         )
                         raise TypeError(msg)
                     else:

--- a/src/static_folders/folder.py
+++ b/src/static_folders/folder.py
@@ -131,32 +131,32 @@ class Folder(FolderLike):
             if attrib_name in self._reserved_attributes:
                 continue
             if isinstance(annotation, type):
-                if issubclass(annotation, Folder):  # i.e. attribute foo: Folder - a class constructor
+                if issubclass(annotation, FolderLike):  # i.e. attribute foo: Folder - a class constructor
                     value = getattr(self, attrib_name, None)
                     folder_name = None
                     if value is None:  # check default wasn't given
                         folder_name = attrib_name
                     elif isinstance(value, _FolderName):
                         folder_name = value.name
-                    elif isinstance(value, Folder):
+                    elif isinstance(value, FolderLike):
                         msg = (
-                            f"Providing a folder annotation with a folder value "
+                            f"Providing a FolderLike annotation with a FolderLike value "
                             f"({attrib_name}: {annotation} = {value}) is deprecated, "
-                            "behaviour was not sound with respect to child file paths. If the intention"
+                            "behaviour was not sound with respect to child file paths. If the intention "
                             "was to specify a custom folder name, you should "
-                            f"migrate to {attrib_name}: {annotation} = FolderName(...) "
+                            f"migrate to {attrib_name}: {annotation} = sf.custom_name(...) "
                         )
                         raise TypeError(msg)
                     elif isinstance(value, Path):
                         # TODO, if we're doing all this at runtime, do we get it at type checking time?
                         # and if not, does that defeat the purpose of this being staticly typed.
                         msg = (
-                            f"Annotating an attribute with a Folder type and a Path value is ambiguous "
+                            f"Annotating an attribute with a FolderLike type and a Path value is ambiguous "
                             f"and not supported (got {attrib_name}: {annotation} = {value}). "
                             f"If you intended to declare a subfolder with a custom folder name, "
-                            f"you should update the Path value to a FolderName value instead.\n"
+                            f"you should update the Path value to a sf.custom_name(...) value instead.\n"
                             f"If you intended to declare a file within the folder, you should update the "
-                            f"Folder annotation to be a Path instead."
+                            f"FolderLike annotation to be a Path instead."
                         )
                         raise TypeError(msg)
                     else:

--- a/src/static_folders/folder.py
+++ b/src/static_folders/folder.py
@@ -22,8 +22,6 @@ U = TypeVar("U", bound="Folder")
 PathLike = typing.Union[str, Path]
 T = TypeVar("T", bound="Folder")
 
-V = TypeVar("V")
-
 
 def _get_annotations(obj: Callable[..., object] | type[Any] | ModuleType) -> dict[str, object]:
     if sys.version_info >= (3, 10):
@@ -63,7 +61,7 @@ class Folder(FolderLike):
     _child_folders: list[FolderLike] = field(init=False, default=Factory(list))
 
     @classmethod
-    def from_path(cls, path: Path) -> Folder:
+    def from_path(cls, path: Path) -> Self:
         return cls(path)
 
     @classmethod
@@ -121,7 +119,7 @@ class Folder(FolderLike):
                             f"and not supported. For class `{type(self).__name__}` got:\n"
                             f"'{attrib_name}: {annotation} = {value!r}'\n"
                             f"If you intended to declare a subfolder with a custom folder name, "
-                            f"you should use `{attrib_name}: FolderLike: FolderLike(name)` instead.\n"
+                            f"you should use `{attrib_name}: FolderLike = FolderLike(name)` instead.\n"
                             f"If you intended to declare a file within the folder, you should use"
                             f" `{attrib_name}: Path: Path(name)` "
                             f"instead."

--- a/src/static_folders/folder.py
+++ b/src/static_folders/folder.py
@@ -43,16 +43,10 @@ def custom_name(name: str, annotation_type: Type[U] = ...) -> U: ...
 
 
 def custom_name(name: str, annotation_type: Type[U] | None = None) -> U | Folder:
-    # We are lying to the type system here, and assuming users don't use this
+    # We are lying to the type system here, and assuming users don't use this in a context where they could
+    # see the return value. We only use the distinct type here as a marker to tell folders from files
+    # TODO should this be implemented via Annotated[str, "custom_folder_name"] instead?
     return _FolderName(name)  # type:ignore[return-value]
-
-
-# def name(value):
-#     """First draft value to distinguish folder directory overrides.
-#
-#     # TODO should we just have FolderName / FileName classes for consistency?
-#     """
-#     return CustomFolderName(value)
 
 
 def _get_annotations(obj: Callable[..., object] | type[Any] | ModuleType) -> dict[str, object]:

--- a/src/static_folders/folder_interface.py
+++ b/src/static_folders/folder_interface.py
@@ -14,9 +14,7 @@ T = TypeVar("T")
 class FolderLike(ABC, Generic[T]):
     location: Path
 
-    # LSP doesn't realist that attrs implements this
-    # @abstractmethod
-    # def __init__(self, location: Path) -> None: ...
+    # LSP doesn't seem to detect attrs implementing the protocol, so converted to an ABC
     @classmethod
     @abstractmethod
     def from_path(cls, path: Path) -> FolderLike[T]:

--- a/src/static_folders/folder_interface.py
+++ b/src/static_folders/folder_interface.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import typing
 from abc import ABC, abstractmethod
+from typing import Generic
 
 from typing_extensions import Type, TypeVar
-from typing import Generic
 
 if typing.TYPE_CHECKING:
     from pathlib import Path

--- a/src/static_folders/folder_interface.py
+++ b/src/static_folders/folder_interface.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 
 import typing
 
-from typing_extensions import Protocol, Type, TypeVar, runtime_checkable, Generic
+from typing_extensions import Type, TypeVar, Generic
 
 if typing.TYPE_CHECKING:
     from pathlib import Path
@@ -13,6 +13,14 @@ T = TypeVar("T")
 
 class FolderLike(ABC, Generic[T]):
     location: Path
+
+    # LSP doesn't realist that attrs implements this
+    # @abstractmethod
+    # def __init__(self, location: Path) -> None: ...
+    @classmethod
+    @abstractmethod
+    def from_path(cls, path: Path) -> FolderLike[T]:
+        pass
 
     @abstractmethod
     def __fspath__(self) -> str: ...

--- a/src/static_folders/folder_interface.py
+++ b/src/static_folders/folder_interface.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import typing
 from abc import ABC, abstractmethod
-from typing import Generic
+from typing import Generic, TypeVar
 
-from typing_extensions import Type, TypeVar
+from typing_extensions import Type
 
 if typing.TYPE_CHECKING:
     from pathlib import Path

--- a/src/static_folders/folder_interface.py
+++ b/src/static_folders/folder_interface.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import typing
 from abc import ABC, abstractmethod
 
-from typing_extensions import Generic, Type, TypeVar
+from typing_extensions import Type, TypeVar
+from typing import Generic
 
 if typing.TYPE_CHECKING:
     from pathlib import Path

--- a/src/static_folders/folder_interface.py
+++ b/src/static_folders/folder_interface.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
+from abc import ABC, abstractmethod
 
 import typing
 
-from typing_extensions import Protocol, Type, TypeVar, runtime_checkable
+from typing_extensions import Protocol, Type, TypeVar, runtime_checkable, Generic
 
 if typing.TYPE_CHECKING:
     from pathlib import Path
@@ -10,10 +11,10 @@ if typing.TYPE_CHECKING:
 T = TypeVar("T")
 
 
-@runtime_checkable
-class FolderLike(Protocol[T]):
+class FolderLike(ABC, Generic[T]):
     location: Path
 
+    @abstractmethod
     def __fspath__(self) -> str: ...
 
     def to_path(self) -> Path:
@@ -26,11 +27,13 @@ class FolderLike(Protocol[T]):
         # since this should be the behaviour in all sane cases
         return self.location / name
 
+    @abstractmethod
     def get_subfolder(self, name: str, subfolder_class: Type[T] = ...) -> T:
         # TODO is this a bad idea? we will have other @overloads of this method
         #  but should expect this override should always work?
         ...
 
+    @abstractmethod
     def create(self, *, mode: int = 0o777, parents: bool = True, exist_ok: bool = True) -> None:
         """Materialise folder representation to directories on disk.
         Subclass may opt to populate child folders eagerly.

--- a/src/static_folders/folder_interface.py
+++ b/src/static_folders/folder_interface.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
-from abc import ABC, abstractmethod
 
 import typing
+from abc import ABC, abstractmethod
 
-from typing_extensions import Type, TypeVar, Generic
+from typing_extensions import Generic, Type, TypeVar
 
 if typing.TYPE_CHECKING:
     from pathlib import Path

--- a/src/static_folders/partitioned_folder.py
+++ b/src/static_folders/partitioned_folder.py
@@ -66,6 +66,7 @@ class FolderPartition(FolderLike[U]):
         class FolderParitionSomeClass(FolderPartition[SomeClass]):
             _type_param = SomeClass
 
+
         f = FolderParitionSomeClass(path)
         ```
         inline dynamically.

--- a/src/static_folders/partitioned_folder.py
+++ b/src/static_folders/partitioned_folder.py
@@ -5,7 +5,7 @@ import typing
 from pathlib import Path
 
 from attrs import define, field
-from typing_extensions import TypeVar, ClassVar, Type
+from typing_extensions import TypeVar, ClassVar, Type, Self
 
 from static_folders import Folder
 from static_folders.folder_interface import FolderLike
@@ -20,7 +20,7 @@ U = TypeVar("U", bound=Folder)
 @define(slots=False)
 class FolderPartition(FolderLike[U]):
     _raw_location: os.PathLike | str
-    partition_class: Type[U] = field(kw_only=True)
+    partition_class: type[U] = field(init=False, repr=False)
     location: Path = field(init=False)
 
     partition_prefix: ClassVar[str] = ""
@@ -31,6 +31,56 @@ class FolderPartition(FolderLike[U]):
 
     def __attrs_post_init__(self) -> None:
         self.location = Path(os.fspath(self._raw_location))
+        # runtime safety check
+        if getattr(type(self), "_type_param", None) is None:
+            # TODO should this be a warning instead? we're crashing on what's usually valid python
+            # TODO wish we could do this in a static analysis safe way. But the crash happens at
+            #  class definition time (unless you're using a FolderPartition as solely a toplevel thing),
+            #  not instantiation time which for now seems safe enough
+            msg = (
+                "FolderPartition instance constructed without providing explicit generics. "
+                "We can't construct partition folder types properly without this. "
+                "You should write e.g. "
+                "FolderPartition[SomeClass](...) not bare FolderPartition(...)"
+            )
+            raise TypeError(msg)
+        else:
+            # bind the captured type parameter to the instance
+            self.partition_class = type(self)._type_param  # type:ignore[attr-defined]
+
+    @classmethod
+    def __class_getitem__(cls, item: Type[U]) -> Self:
+        """Class Getitem is called when you call square brackets (getitem) on a class.
+        i.e. when you call the constructor of a generic class with explicit type annotations
+        f= FolderPartition[SomeClass](path)
+
+        We override __class_getitem__ to create a subclass of FolderPartition on which we store
+        the class provided in square brackets so our instance f has access to it. We do this at
+        runtime using the 3-argument call to type() which creates new types.
+
+        in spirit, we're doing:
+        ```
+        class FolderParitionSomeClass(FolderPartition[SomeClass]):
+            _type_param = SomeClass
+
+
+        f = FolderParitionSomeClass(path)
+        # or more directly
+        ```
+        inline dynamically. Note right now there's no cache, so each FolderParitionSomeClass instance
+        is unrelated.
+        """
+        if isinstance(item, TypeVar):
+            # This is called at class definition time where item is a Generic, don't do anything crazy
+            # (this is equivalent to could be super().__class_getitem__(item))
+            return cls
+        # Otherwise we specialise PartitionedFolder[Kind]
+        # and make a new subclass of PartitionedFolder, which we call PartitionedFolder[Kind_static_folders_dynamic]
+        # with the suffix embedded so that a user can see there's some spooky magic going on if
+        # they ever assign x = FolderPartition[SomeClass] and look at x
+        subclass = type(f"{cls.__name__}[{item.__name__}_static_folders_dynamic]", (cls,), {})
+        subclass._type_param = item  # type:ignore[attr-defined]
+        return subclass  # type:ignore[return-value]
 
     def __fspath__(self) -> str:
         return str(self.location)

--- a/src/static_folders/partitioned_folder.py
+++ b/src/static_folders/partitioned_folder.py
@@ -5,7 +5,7 @@ import typing
 from pathlib import Path
 
 from attrs import define, field
-from typing_extensions import TypeVar, ClassVar, Type, Self
+from typing_extensions import ClassVar, Self, Type, TypeVar
 
 from static_folders import Folder
 from static_folders.folder_interface import FolderLike

--- a/src/static_folders/partitioned_folder.py
+++ b/src/static_folders/partitioned_folder.py
@@ -16,6 +16,9 @@ if typing.TYPE_CHECKING:
 T = TypeVar("T", bound=Folder)
 U = TypeVar("U", bound=Folder)
 
+# module level, top of partitioned_folder.py
+_class_getitem_cache: dict[tuple[type, type], type] = {}
+
 
 @define(slots=False)
 class FolderPartition(FolderLike[U]):
@@ -58,17 +61,14 @@ class FolderPartition(FolderLike[U]):
         the class provided in square brackets so our instance f has access to it. We do this at
         runtime using the 3-argument call to type() which creates new types.
 
-        in spirit, we're doing:
+        in spirit, we're creating:
         ```
         class FolderParitionSomeClass(FolderPartition[SomeClass]):
             _type_param = SomeClass
 
-
         f = FolderParitionSomeClass(path)
-        # or more directly
         ```
-        inline dynamically. Note right now there's no cache, so each FolderParitionSomeClass instance
-        is unrelated.
+        inline dynamically.
         """
         if isinstance(item, TypeVar):
             # This is called at class definition time where item is a Generic, don't do anything crazy
@@ -78,9 +78,13 @@ class FolderPartition(FolderLike[U]):
         # and make a new subclass of PartitionedFolder, which we call PartitionedFolder[Kind_static_folders_dynamic]
         # with the suffix embedded so that a user can see there's some spooky magic going on if
         # they ever assign x = FolderPartition[SomeClass] and look at x
+        cache_key = (cls, item)
+        if cache_key in _class_getitem_cache:
+            return _class_getitem_cache[cache_key]  # type: ignore[return-value]
         subclass = type(f"{cls.__name__}[{item.__name__}_static_folders_dynamic]", (cls,), {})
-        subclass._type_param = item  # type:ignore[attr-defined]
-        return subclass  # type:ignore[return-value]
+        subclass._type_param = item  # type: ignore[attr-defined]
+        _class_getitem_cache[cache_key] = subclass
+        return subclass  # type: ignore[return-value]
 
     def __fspath__(self) -> str:
         return str(self.location)

--- a/src/static_folders/partitioned_folder.py
+++ b/src/static_folders/partitioned_folder.py
@@ -41,7 +41,7 @@ class FolderPartition(FolderLike[U]):
                 "FolderPartition instance constructed without providing explicit generics. "
                 "We can't construct partition folder types properly without this. "
                 "You should write e.g. "
-                "FolderPartition[SomeClass](...) not bare FolderPartition(...)"
+                "attr: FolderPartition[SomeClass] = FolderPartition[SomeClass](...) not bare FolderPartition(...)"
             )
             raise TypeError(msg)
         else:

--- a/src/static_folders/partitioned_folder.py
+++ b/src/static_folders/partitioned_folder.py
@@ -72,7 +72,7 @@ class FolderPartition(FolderLike[U]):
         """
         if isinstance(item, TypeVar):
             # This is called at class definition time where item is a Generic, don't do anything crazy
-            # (this is equivalent to could be super().__class_getitem__(item))
+            # (this is equivalent to super().__class_getitem__(item))
             return cls
         # Otherwise we specialise PartitionedFolder[Kind]
         # and make a new subclass of PartitionedFolder, which we call PartitionedFolder[Kind_static_folders_dynamic]

--- a/src/static_folders/partitioned_folder.py
+++ b/src/static_folders/partitioned_folder.py
@@ -25,6 +25,10 @@ class FolderPartition(FolderLike[U]):
 
     partition_prefix: ClassVar[str] = ""
 
+    @classmethod
+    def from_path(cls, path: Path) -> FolderPartition:
+        return cls(path)
+
     def __attrs_post_init__(self) -> None:
         self.location = Path(os.fspath(self._raw_location))
 

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -86,29 +86,18 @@ def test_create(tmp_path: Path) -> None:
     assert not n.nest.file.is_file()
 
 
-@pytest.mark.parametrize("custom_name_func", [True, False])
-def test_nested(tmp_path: Path, custom_name_func: bool) -> None:
-    tmp_path = Path("test")  # needs to not be "." or there's a soundness issue around deferred
+def test_nested(tmp_path: Path) -> None:
+    # tmp_path cannot be ".", what would that mean when paths are resolved?
 
     class PhotoYearFolder(Folder):
         index: Path = Path("index.md")
 
-    if custom_name_func:
-
-        class Photos(Folder):
-            temp: Folder
-            y2024: PhotoYearFolder
-            # provide concrete path which doesn't have y prefix
-            y2025: PhotoYearFolder = PhotoYearFolder("2025")
-            readme: Path = Path("readme.md")
-    else:
-
-        class Photos(Folder):  # type:ignore[no-redef]
-            temp: Folder
-            y2024: PhotoYearFolder
-            # provide concrete path which doesn't have y prefix
-            y2025: PhotoYearFolder = PhotoYearFolder("2025")
-            readme: Path = Path("readme.md")
+    class Photos(Folder):
+        temp: Folder
+        y2024: PhotoYearFolder
+        # provide concrete path which doesn't have y prefix
+        y2025: PhotoYearFolder = PhotoYearFolder("2025")
+        readme: Path = Path("readme.md")
 
     photos = Photos(tmp_path)
     assert isinstance(photos.readme, Path)
@@ -133,7 +122,7 @@ def test_exotic_attributes_okay(tmp_path: Path) -> None:
         class Nested(Folder):
             attrib = lambda x: print(x)  # noqa:E731, PLW0108
 
-        subfolder: A = A("custom_nameed_subfolder")
+        subfolder: A = A("custom_named_subfolder")
 
         readme: Path = Path("readme.txt")
 
@@ -148,94 +137,8 @@ class AsgsYearDir(Folder):
     sa2: Path = Path("SA2.gpkg")
 
 
-class AsgsLayersByYear(FolderPartition[AsgsYearDir]):
-    pass
 
 
-def test_partitioned_folder(path_not_on_disk: Path) -> None:
-    f = AsgsLayersByYear(path_not_on_disk)
-    y2016_dir_subfolder = f.get_subfolder("2016")
-    assert not isinstance(y2016_dir_subfolder, AsgsYearDir)
-    y2016_dir = f.get_partition("2016")
-    assert isinstance(y2016_dir, AsgsYearDir)
-    assert y2016_dir.sa1 == path_not_on_disk / "2016" / "SA1.gpkg"
-
-    # check/ document IO behaviour
-    assert not f.to_path().exists()
-    assert not y2016_dir.sa1.exists()
-    f.create()
-    assert f.to_path().is_dir()
-    # child under partition can't be materialised
-    assert not y2016_dir.sa1.exists()
-
-
-def test_enumerated_partitioned_folder(path_not_on_disk: Path) -> None:
-    # repeat test with EnumeratedFolderPartition
-
-    class EnumeratedAsgsLayersByYear(EnumeratedFolderPartition[AsgsYearDir]):
-        partition_names = ("2016", "2021")
-
-    f = EnumeratedAsgsLayersByYear(path_not_on_disk)
-    y2016_dir_subfolder = f.get_subfolder("2016")
-    assert not isinstance(y2016_dir_subfolder, AsgsYearDir)
-    y2016_dir = f.get_partition("2016")
-    assert isinstance(y2016_dir, AsgsYearDir)
-    assert y2016_dir.sa1 == path_not_on_disk / "2016" / "SA1.gpkg"
-
-    # check/ document IO behaviour
-    assert not f.to_path().exists()
-    assert not y2016_dir.sa1.exists()
-    f.create()
-    assert f.to_path().is_dir()
-    # listed child under partition can be materialised
-    assert y2016_dir.to_path().is_dir()
-    assert f.get_subfolder("2021").to_path().exists()
-    assert not f.get_subfolder("2023").to_path().exists()
-    with pytest.raises(NameError):
-        f.get_partition("2023")
-
-
-def test_prefixed_enumerated_partitioned_folder(path_not_on_disk: Path) -> None:
-    # repeat test with EnumeratedFolderPartition
-
-    class EnumeratedAsgsLayersByYear(EnumeratedFolderPartition[AsgsYearDir]):
-        partition_prefix = "year="
-        partition_names = ("2016", "2021")
-
-    f = EnumeratedAsgsLayersByYear(path_not_on_disk)
-    y2016_dir_subfolder = f.get_subfolder("year=2016")  # conforms but wrong method
-    assert not isinstance(y2016_dir_subfolder, AsgsYearDir)
-    y2016_dir = f.get_partition("year=2016")  # explicit prefix
-    assert y2016_dir.sa1 == path_not_on_disk / "year=2016" / "SA1.gpkg"
-    y2016_dir2 = f.get_partition("2016")  # implicit prefix
-    assert y2016_dir == y2016_dir2  # attrs equality implies equal
-    assert y2016_dir != y2016_dir_subfolder
-    assert isinstance(y2016_dir2, AsgsYearDir)
-    assert y2016_dir2.sa1 == path_not_on_disk / "year=2016" / "SA1.gpkg"
-
-    # check/ document IO behaviour
-    assert not f.to_path().exists()
-    assert not y2016_dir.sa1.exists()
-    f.create()
-    assert f.to_path().is_dir()
-    # listed child under partition can be materialised
-    assert y2016_dir.to_path().is_dir()
-    assert f.get_subfolder("year=2021").to_path().exists()
-    assert not f.get_subfolder("year=2023").to_path().exists()
-    with pytest.raises(NameError):
-        f.get_partition("year=2023")
-
-
-def test_enumerated_subfolder_logical(path_not_on_disk: Path) -> None:
-    class EnumeratedAsgsLayersByYear(EnumeratedFolderPartition[AsgsYearDir]):
-        partition_prefix = "year="
-        partition_names = ("2016", "2021")
-
-    f = EnumeratedAsgsLayersByYear(path_not_on_disk)
-
-    assert type(f.get_subfolder("foo")) == Folder  # Shouldn't be AsgsYearDir, doesn't conform # noqa: E721
-    assert type(f.get_subfolder("foo", subfolder_class=AsgsYearDir)) == AsgsYearDir  # noqa: E721
-    assert type(f.get_partition("2016")) == AsgsYearDir  # noqa: E721
 
 
 def test_attrs_subclass_post_init(path_not_on_disk: Path) -> None:

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -143,7 +143,7 @@ class AsgsLayersByYear(FolderPartition[AsgsYearDir]):
 
 
 def test_partitioned_folder(path_not_on_disk: Path) -> None:
-    f = AsgsLayersByYear(path_not_on_disk, partition_class=AsgsYearDir)
+    f = AsgsLayersByYear(path_not_on_disk)
     y2016_dir_subfolder = f.get_subfolder("2016")
     assert not isinstance(y2016_dir_subfolder, AsgsYearDir)
     y2016_dir = f.get_partition("2016")
@@ -165,7 +165,7 @@ def test_enumerated_partitioned_folder(path_not_on_disk: Path) -> None:
     class EnumeratedAsgsLayersByYear(EnumeratedFolderPartition[AsgsYearDir]):
         partition_names = ("2016", "2021")
 
-    f = EnumeratedAsgsLayersByYear(path_not_on_disk, partition_class=AsgsYearDir)
+    f = EnumeratedAsgsLayersByYear(path_not_on_disk)
     y2016_dir_subfolder = f.get_subfolder("2016")
     assert not isinstance(y2016_dir_subfolder, AsgsYearDir)
     y2016_dir = f.get_partition("2016")
@@ -192,7 +192,7 @@ def test_prefixed_enumerated_partitioned_folder(path_not_on_disk: Path) -> None:
         partition_prefix = "year="
         partition_names = ("2016", "2021")
 
-    f = EnumeratedAsgsLayersByYear(path_not_on_disk, partition_class=AsgsYearDir)
+    f = EnumeratedAsgsLayersByYear(path_not_on_disk)
     y2016_dir_subfolder = f.get_subfolder("year=2016")  # conforms but wrong method
     assert not isinstance(y2016_dir_subfolder, AsgsYearDir)
     y2016_dir = f.get_partition("year=2016")  # explicit prefix
@@ -221,7 +221,7 @@ def test_enumerated_subfolder_logical(path_not_on_disk: Path) -> None:
         partition_prefix = "year="
         partition_names = ("2016", "2021")
 
-    f = EnumeratedAsgsLayersByYear(path_not_on_disk, partition_class=AsgsYearDir)
+    f = EnumeratedAsgsLayersByYear(path_not_on_disk)
 
     assert type(f.get_subfolder("foo")) == Folder  # Shouldn't be AsgsYearDir, doesn't conform # noqa: E721
     assert type(f.get_subfolder("foo", subfolder_class=AsgsYearDir)) == AsgsYearDir  # noqa: E721
@@ -292,7 +292,7 @@ def test_eager_folder_default_errors(path_not_on_disk: Path) -> None:
 
 def test_eager_folder_default_errors_folder_partition(path_not_on_disk: Path) -> None:
     class Custom2(Folder):
-        a: FolderPartition = FolderPartition("foo", partition_class=Folder)
+        a: FolderPartition = FolderPartition[Folder]("foo")
 
     with pytest.raises(
         TypeError,
@@ -301,3 +301,12 @@ def test_eager_folder_default_errors_folder_partition(path_not_on_disk: Path) ->
         + re.escape(" is deprecated"),
     ):
         Custom2(path_not_on_disk)
+
+
+def test_folder_partition_generics_required(path_not_on_disk: Path) -> None:
+    with pytest.raises(
+        TypeError, match=re.escape("FolderPartition instance constructed without providing explicit generics")
+    ):
+
+        class _Custom2(Folder):
+            a: FolderPartition = FolderPartition("foo")

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -7,7 +7,6 @@ import pytest
 from attrs import define
 from static_folders import Folder, FolderPartition
 from static_folders.partitioned_folder import EnumeratedFolderPartition
-import static_folders as sf
 
 
 @pytest.fixture
@@ -86,18 +85,29 @@ def test_create(tmp_path: Path) -> None:
     assert not n.nest.file.is_file()
 
 
-def test_nested(tmp_path: Path) -> None:
+@pytest.mark.parametrize("custom_name_func", [True, False])
+def test_nested(tmp_path: Path, custom_name_func: bool) -> None:
     tmp_path = Path("test")  # needs to not be "." or there's a soundness issue around deferred
 
     class PhotoYearFolder(Folder):
         index: Path = Path("index.md")
 
-    class Photos(Folder):
-        temp: Folder
-        y2024: PhotoYearFolder
-        # provide concrete path which doesn't have y prefix
-        y2025: PhotoYearFolder = sf.custom_name("2025", annotation_type=PhotoYearFolder)
-        readme: Path = Path("readme.md")
+    if custom_name_func:
+
+        class Photos(Folder):
+            temp: Folder
+            y2024: PhotoYearFolder
+            # provide concrete path which doesn't have y prefix
+            y2025: PhotoYearFolder = PhotoYearFolder("2025")
+            readme: Path = Path("readme.md")
+    else:
+
+        class Photos(Folder):  # type:ignore[no-redef]
+            temp: Folder
+            y2024: PhotoYearFolder
+            # provide concrete path which doesn't have y prefix
+            y2025: PhotoYearFolder = PhotoYearFolder("2025")
+            readme: Path = Path("readme.md")
 
     photos = Photos(tmp_path)
     assert isinstance(photos.readme, Path)
@@ -122,7 +132,7 @@ def test_exotic_attributes_okay(tmp_path: Path) -> None:
         class Nested(Folder):
             attrib = lambda x: print(x)  # noqa:E731
 
-        subfolder: A = sf.custom_name("custom_name_not_subfolder", annotation_type=A)
+        subfolder: A = A("custom_nameed_subfolder")
 
         readme: Path = Path("readme.txt")
 
@@ -242,25 +252,35 @@ def test_attrs_subclass_post_init(path_not_on_disk: Path) -> None:
 def test_attrs_subclass_post_init_missing(path_not_on_disk: Path) -> None:
     # documenting that if we call super properly, this behaves properly.
     # but you need to call super!
+    class CustomWorking(Folder):
+        def __attrs_post_init__(self) -> None:
+            super().__attrs_post_init__()
+
+    a = CustomWorking(path_not_on_disk)
+    assert a.get_subfolder("foo") == path_not_on_disk / "foo"
+
     # If we had an api based around decorators, this wouldn't come up
     class Custom(Folder):
         def __attrs_post_init__(self) -> None:
             pass
 
-    a = Custom(path_not_on_disk)
-    a.get_subfolder("foo")
+    b = Custom(path_not_on_disk)
+    b.get_subfolder("foo")
 
 
 def test_custom_folder_names(path_not_on_disk: Path) -> None:
+    # https://github.com/m-richards/static_folders/issues/11
     class Custom(Folder):
         a: Folder
-        b: Folder = sf.custom_name("02_b", annotation_type=Folder)
-        c: AsgsYearDir = sf.custom_name("02_c", annotation_type=AsgsYearDir)
+        b: Folder = Folder("02_b")
+        c: AsgsYearDir = AsgsYearDir("02_c")
 
     folder = Custom(path_not_on_disk)
     assert isinstance(folder.a, Folder)
     assert folder.a.to_path() == path_not_on_disk / "a"
+    # this needs to be under path_not_on_disk, not a relative path to cwd
     assert folder.b.to_path() == path_not_on_disk / "02_b"
+    assert folder.c.sa1 == path_not_on_disk / "02_c" / "SA1.gpkg"
 
 
 def test_ambiguous_annotations_error_out(path_not_on_disk: Path) -> None:
@@ -269,37 +289,9 @@ def test_ambiguous_annotations_error_out(path_not_on_disk: Path) -> None:
 
     with pytest.raises(
         TypeError,
-        match=re.escape(
-            "Annotating an attribute with a FolderLike type and a Path value is ambiguous and not supported"
-        ),
+        match=re.escape("Annotating an attribute with a FolderLike type and a Path value is incorrect"),
     ):
         Custom(path_not_on_disk)
-
-
-def test_eager_folder_default_errors(path_not_on_disk: Path) -> None:
-    class Custom(Folder):
-        a: Folder = Folder("foo")
-
-    with pytest.raises(
-        TypeError,
-        match=re.escape("Providing a FolderLike annotation with a FolderLike value ")
-        + ".*"
-        + re.escape(" is deprecated"),
-    ):
-        Custom(path_not_on_disk)
-
-
-def test_eager_folder_default_errors_folder_partition(path_not_on_disk: Path) -> None:
-    class Custom2(Folder):
-        a: FolderPartition = FolderPartition[Folder]("foo")
-
-    with pytest.raises(
-        TypeError,
-        match=re.escape("Providing a FolderLike annotation with a FolderLike value ")
-        + ".*"
-        + re.escape(" is deprecated"),
-    ):
-        Custom2(path_not_on_disk)
 
 
 def test_folder_partition_generics_required(path_not_on_disk: Path) -> None:

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -127,11 +127,11 @@ def test_nested(tmp_path: Path, custom_name_func: bool) -> None:
 
 def test_exotic_attributes_okay(tmp_path: Path) -> None:
     class A(Folder):
-        attrib = lambda x: print(x)  # noqa:E731
+        attrib = lambda x: print(x)  # noqa:E731, PLW0108
 
     class B(Folder):
         class Nested(Folder):
-            attrib = lambda x: print(x)  # noqa:E731
+            attrib = lambda x: print(x)  # noqa:E731, PLW0108
 
         subfolder: A = A("custom_nameed_subfolder")
 

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -6,8 +6,8 @@ from typing import ClassVar
 import pytest
 from attrs import define
 from static_folders import Folder, FolderPartition
-from static_folders.folder import FolderName
 from static_folders.partitioned_folder import EnumeratedFolderPartition
+import static_folders as sf
 
 
 @pytest.fixture
@@ -95,8 +95,9 @@ def test_nested(tmp_path: Path) -> None:
     class Photos(Folder):
         temp: Folder
         y2024: PhotoYearFolder
-        y2025: PhotoYearFolder = FolderName(Path("2025"))  # provide concrete which doesn't have y prefix
-        y2026: PhotoYearFolder = FolderName("2026")  # string arg is fine too (path variant now silly)
+        y2025: PhotoYearFolder = sf.custom_name(
+            "2025", annotation_type=PhotoYearFolder
+        )  # provide concrete which doesn't have y prefix
         readme: Path = Path("readme.md")
 
     photos = Photos(tmp_path)
@@ -108,9 +109,8 @@ def test_nested(tmp_path: Path) -> None:
     assert photos.y2024.index == tmp_path / "y2024" / "index.md"
     assert photos.y2025.index == tmp_path / "2025" / "index.md"
     assert photos.y2025.to_path() == tmp_path / "2025"
-    assert photos.y2026.index == tmp_path / "2026" / "index.md"
-    child_folder2 = photos.get_subfolder("2026", subfolder_class=PhotoYearFolder)
-    child_folder2a = photos.get_subfolder("2026", subfolder_class=Folder)
+    child_folder2 = photos.get_subfolder("2025", subfolder_class=PhotoYearFolder)
+    child_folder2a = photos.get_subfolder("2025", subfolder_class=Folder)
     assert isinstance(child_folder2, PhotoYearFolder)
     assert isinstance(child_folder2a, Folder) and not isinstance(child_folder2a, PhotoYearFolder)  # noqa: PT018
 
@@ -123,7 +123,7 @@ def test_exotic_attributes_okay(tmp_path: Path) -> None:
         class Nested(Folder):
             attrib = lambda x: print(x)  # noqa:E731
 
-        subfolder: A = FolderName("custom_name_not_subfolder")
+        subfolder: A = sf.custom_name("custom_name_not_subfolder", annotation_type=A)
 
         readme: Path = Path("readme.txt")
 
@@ -255,9 +255,21 @@ def test_attrs_subclass_post_init_missing(path_not_on_disk: Path) -> None:
 def test_custom_folder_names(path_not_on_disk: Path) -> None:
     class Custom(Folder):
         a: Folder
-        b: Folder = FolderName("02_b")
+        b: Folder = sf.custom_name("02_b", annotation_type=Folder)
+        c: AsgsYearDir = sf.custom_name("02_c", annotation_type=AsgsYearDir)
 
     folder = Custom(path_not_on_disk)
     assert isinstance(folder.a, Folder)
     assert folder.a.to_path() == path_not_on_disk / "a"
     assert folder.b.to_path() == path_not_on_disk / "02_b"
+
+
+def test_ambiguous_annotations_error_out(path_not_on_disk: Path) -> None:
+    class Custom(Folder):
+        a: Folder = Path("foo.txt")  # type:ignore[assignment]
+
+    with pytest.raises(
+        TypeError,
+        match=re.escape("Annotating an attribute with a Folder type and a Path value is ambiguous and not supported"),
+    ):
+        Custom(path_not_on_disk)

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -270,7 +270,9 @@ def test_ambiguous_annotations_error_out(path_not_on_disk: Path) -> None:
 
     with pytest.raises(
         TypeError,
-        match=re.escape("Annotating an attribute with a FolderLike type and a Path value is ambiguous and not supported"),
+        match=re.escape(
+            "Annotating an attribute with a FolderLike type and a Path value is ambiguous and not supported"
+        ),
     ):
         Custom(path_not_on_disk)
 
@@ -281,9 +283,12 @@ def test_eager_folder_default_errors(path_not_on_disk: Path) -> None:
 
     with pytest.raises(
         TypeError,
-        match=re.escape("Providing a FolderLike annotation with a FolderLike value ") + ".*" + re.escape(" is deprecated"),
+        match=re.escape("Providing a FolderLike annotation with a FolderLike value ")
+        + ".*"
+        + re.escape(" is deprecated"),
     ):
         Custom(path_not_on_disk)
+
 
 def test_eager_folder_default_errors_folder_partition(path_not_on_disk: Path) -> None:
     class Custom2(Folder):
@@ -291,6 +296,8 @@ def test_eager_folder_default_errors_folder_partition(path_not_on_disk: Path) ->
 
     with pytest.raises(
         TypeError,
-        match=re.escape("Providing a FolderLike annotation with a FolderLike value ") + ".*" + re.escape(" is deprecated"),
+        match=re.escape("Providing a FolderLike annotation with a FolderLike value ")
+        + ".*"
+        + re.escape(" is deprecated"),
     ):
         Custom2(path_not_on_disk)

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -6,6 +6,7 @@ from typing import ClassVar
 import pytest
 from attrs import define
 from static_folders import Folder, FolderPartition
+from static_folders.folder import FolderName
 from static_folders.partitioned_folder import EnumeratedFolderPartition
 
 
@@ -86,7 +87,7 @@ def test_create(tmp_path: Path) -> None:
 
 
 def test_nested(tmp_path: Path) -> None:
-    tmp_path = Path(".")
+    tmp_path = Path("test")  # needs to not be "." or there's a soundness issue around deferred
 
     class PhotoYearFolder(Folder):
         index: Path = Path("index.md")
@@ -94,8 +95,8 @@ def test_nested(tmp_path: Path) -> None:
     class Photos(Folder):
         temp: Folder
         y2024: PhotoYearFolder
-        y2025: PhotoYearFolder = PhotoYearFolder(Path("2025"))  # provide concrete which doesn't have y prefix
-        y2026: PhotoYearFolder = PhotoYearFolder("2026")  # string arg is fine too
+        y2025: PhotoYearFolder = FolderName(Path("2025"))  # provide concrete which doesn't have y prefix
+        y2026: PhotoYearFolder = FolderName("2026")  # string arg is fine too (path variant now silly)
         readme: Path = Path("readme.md")
 
     photos = Photos(tmp_path)
@@ -106,6 +107,7 @@ def test_nested(tmp_path: Path) -> None:
     assert photos.readme == tmp_path / "readme.md"
     assert photos.y2024.index == tmp_path / "y2024" / "index.md"
     assert photos.y2025.index == tmp_path / "2025" / "index.md"
+    assert photos.y2025.to_path() == tmp_path / "2025"
     assert photos.y2026.index == tmp_path / "2026" / "index.md"
     child_folder2 = photos.get_subfolder("2026", subfolder_class=PhotoYearFolder)
     child_folder2a = photos.get_subfolder("2026", subfolder_class=Folder)
@@ -121,7 +123,7 @@ def test_exotic_attributes_okay(tmp_path: Path) -> None:
         class Nested(Folder):
             attrib = lambda x: print(x)  # noqa:E731
 
-        subfolder: A = A("custom_name_not_subfolder")
+        subfolder: A = FolderName("custom_name_not_subfolder")
 
         readme: Path = Path("readme.txt")
 
@@ -248,3 +250,14 @@ def test_attrs_subclass_post_init_missing(path_not_on_disk: Path) -> None:
 
     a = Custom(path_not_on_disk)
     a.get_subfolder("foo")
+
+
+def test_custom_folder_names(path_not_on_disk: Path) -> None:
+    class Custom(Folder):
+        a: Folder
+        b: Folder = FolderName("02_b")
+
+    folder = Custom(path_not_on_disk)
+    assert isinstance(folder.a, Folder)
+    assert folder.a.to_path() == path_not_on_disk / "a"
+    assert folder.b.to_path() == path_not_on_disk / "02_b"

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -95,9 +95,8 @@ def test_nested(tmp_path: Path) -> None:
     class Photos(Folder):
         temp: Folder
         y2024: PhotoYearFolder
-        y2025: PhotoYearFolder = sf.custom_name(
-            "2025", annotation_type=PhotoYearFolder
-        )  # provide concrete which doesn't have y prefix
+        # provide concrete path which doesn't have y prefix
+        y2025: PhotoYearFolder = sf.custom_name("2025", annotation_type=PhotoYearFolder)
         readme: Path = Path("readme.md")
 
     photos = Photos(tmp_path)
@@ -310,3 +309,7 @@ def test_folder_partition_generics_required(path_not_on_disk: Path) -> None:
 
         class _Custom2(Folder):
             a: FolderPartition = FolderPartition("foo")
+
+    # case which is permitted
+    class _Custom3(Folder):
+        a: FolderPartition = FolderPartition[Folder]("foo")

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -5,6 +5,7 @@ from typing import ClassVar
 
 import pytest
 from attrs import define
+
 from static_folders import Folder, FolderPartition
 from static_folders.partitioned_folder import EnumeratedFolderPartition
 

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -7,7 +7,6 @@ import pytest
 from attrs import define
 
 from static_folders import Folder, FolderPartition
-from static_folders.partitioned_folder import EnumeratedFolderPartition
 
 
 @pytest.fixture
@@ -135,10 +134,6 @@ class AsgsYearDir(Folder):
 
     sa1: Path = Path("SA1.gpkg")
     sa2: Path = Path("SA2.gpkg")
-
-
-
-
 
 
 def test_attrs_subclass_post_init(path_not_on_disk: Path) -> None:

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -302,6 +302,29 @@ def test_folder_partition_generics_required(path_not_on_disk: Path) -> None:
         class _Custom2(Folder):
             a: FolderPartition = FolderPartition("foo")
 
+    with pytest.raises(
+        TypeError, match=re.escape("FolderPartition instance constructed without providing explicit generics")
+    ):
+
+        class _Custom3(Folder):
+            a: FolderPartition[AsgsYearDir] = FolderPartition("foo")
+
+    class _Custom4(Folder):
+        a: FolderPartition = FolderPartition[AsgsYearDir]("foo")
+
+    with pytest.raises(TypeError, match=re.escape("Building Class _Custom4 failed on constructing attribute")):
+        # TODO this case fails at instantiation time, not class initialisation, that's annoying
+        _Custom4(path_not_on_disk)
+
     # case which is permitted
-    class _Custom3(Folder):
-        a: FolderPartition = FolderPartition[Folder]("foo")
+    class _Custom5(AsgsYearDir):
+        a: FolderPartition[AsgsYearDir]
+
+    test = _Custom5(path_not_on_disk)
+    assert test.a.get_partition("baz").sa1 == path_not_on_disk / "a" / "baz" / "sa1.gpkg"
+
+    class _Custom6(AsgsYearDir):
+        a: FolderPartition[AsgsYearDir] = FolderPartition[AsgsYearDir]("foo")
+
+    test2 = _Custom6(path_not_on_disk)
+    assert test2.a.get_partition("baz").sa1 == path_not_on_disk / "foo" / "baz" / "sa1.gpkg"

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -220,10 +220,10 @@ def test_folder_partition_generics_required(path_not_on_disk: Path) -> None:
         a: FolderPartition[AsgsYearDir]
 
     test = _Custom5(path_not_on_disk)
-    assert test.a.get_partition("baz").sa1 == path_not_on_disk / "a" / "baz" / "sa1.gpkg"
+    assert test.a.get_partition("baz").sa1 == path_not_on_disk / "a" / "baz" / "SA1.gpkg"
 
     class _Custom6(AsgsYearDir):
         a: FolderPartition[AsgsYearDir] = FolderPartition[AsgsYearDir]("foo")
 
     test2 = _Custom6(path_not_on_disk)
-    assert test2.a.get_partition("baz").sa1 == path_not_on_disk / "foo" / "baz" / "sa1.gpkg"
+    assert test2.a.get_partition("baz").sa1 == path_not_on_disk / "foo" / "baz" / "SA1.gpkg"

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -270,6 +270,27 @@ def test_ambiguous_annotations_error_out(path_not_on_disk: Path) -> None:
 
     with pytest.raises(
         TypeError,
-        match=re.escape("Annotating an attribute with a Folder type and a Path value is ambiguous and not supported"),
+        match=re.escape("Annotating an attribute with a FolderLike type and a Path value is ambiguous and not supported"),
     ):
         Custom(path_not_on_disk)
+
+
+def test_eager_folder_default_errors(path_not_on_disk: Path) -> None:
+    class Custom(Folder):
+        a: Folder = Folder("foo")
+
+    with pytest.raises(
+        TypeError,
+        match=re.escape("Providing a FolderLike annotation with a FolderLike value ") + ".*" + re.escape(" is deprecated"),
+    ):
+        Custom(path_not_on_disk)
+
+def test_eager_folder_default_errors_folder_partition(path_not_on_disk: Path) -> None:
+    class Custom2(Folder):
+        a: FolderPartition = FolderPartition("foo", partition_class=Folder)
+
+    with pytest.raises(
+        TypeError,
+        match=re.escape("Providing a FolderLike annotation with a FolderLike value ") + ".*" + re.escape(" is deprecated"),
+    ):
+        Custom2(path_not_on_disk)

--- a/test/test_folder_partition.py
+++ b/test/test_folder_partition.py
@@ -1,0 +1,110 @@
+from pathlib import Path
+import pytest
+
+from static_folders import EnumeratedFolderPartition, Folder, FolderPartition
+from test_basic import AsgsYearDir
+
+
+@pytest.fixture
+def path_not_on_disk(tmp_path: Path) -> Path:
+    # get a path which pytest isn't mkdiring
+    return tmp_path / "new_dir_not_on_disk"
+
+class AsgsLayersByYear(FolderPartition[AsgsYearDir]):
+    pass
+
+def test_partitioned_folder(path_not_on_disk: Path) -> None:
+    f = AsgsLayersByYear(path_not_on_disk)
+    y2016_dir_subfolder = f.get_subfolder("2016")
+    assert not isinstance(y2016_dir_subfolder, AsgsYearDir)
+    y2016_dir = f.get_partition("2016")
+    assert isinstance(y2016_dir, AsgsYearDir)
+    assert y2016_dir.sa1 == path_not_on_disk / "2016" / "SA1.gpkg"
+
+    # check/ document IO behaviour
+    assert not f.to_path().exists()
+    assert not y2016_dir.sa1.exists()
+    f.create()
+    assert f.to_path().is_dir()
+    # child under partition can't be materialised
+    assert not y2016_dir.sa1.exists()
+
+
+def test_enumerated_partitioned_folder(path_not_on_disk: Path) -> None:
+    # repeat test with EnumeratedFolderPartition
+
+    class EnumeratedAsgsLayersByYear(EnumeratedFolderPartition[AsgsYearDir]):
+        partition_names = ("2016", "2021")
+
+    f = EnumeratedAsgsLayersByYear(path_not_on_disk)
+    y2016_dir_subfolder = f.get_subfolder("2016")
+    assert not isinstance(y2016_dir_subfolder, AsgsYearDir)
+    y2016_dir = f.get_partition("2016")
+    assert isinstance(y2016_dir, AsgsYearDir)
+    assert y2016_dir.sa1 == path_not_on_disk / "2016" / "SA1.gpkg"
+
+    # check/ document IO behaviour
+    assert not f.to_path().exists()
+    assert not y2016_dir.sa1.exists()
+    f.create()
+    assert f.to_path().is_dir()
+    # listed child under partition can be materialised
+    assert y2016_dir.to_path().is_dir()
+    assert f.get_subfolder("2021").to_path().exists()
+    assert not f.get_subfolder("2023").to_path().exists()
+    with pytest.raises(NameError):
+        f.get_partition("2023")
+
+
+def test_prefixed_enumerated_partitioned_folder(path_not_on_disk: Path) -> None:
+    # repeat test with EnumeratedFolderPartition
+
+    class EnumeratedAsgsLayersByYear(EnumeratedFolderPartition[AsgsYearDir]):
+        partition_prefix = "year="
+        partition_names = ("2016", "2021")
+
+    f = EnumeratedAsgsLayersByYear(path_not_on_disk)
+    y2016_dir_subfolder = f.get_subfolder("year=2016")  # conforms but wrong method
+    assert not isinstance(y2016_dir_subfolder, AsgsYearDir)
+    y2016_dir = f.get_partition("year=2016")  # explicit prefix
+    assert y2016_dir.sa1 == path_not_on_disk / "year=2016" / "SA1.gpkg"
+    y2016_dir2 = f.get_partition("2016")  # implicit prefix
+    assert y2016_dir == y2016_dir2  # attrs equality implies equal
+    assert y2016_dir != y2016_dir_subfolder
+    assert isinstance(y2016_dir2, AsgsYearDir)
+    assert y2016_dir2.sa1 == path_not_on_disk / "year=2016" / "SA1.gpkg"
+
+    # check/ document IO behaviour
+    assert not f.to_path().exists()
+    assert not y2016_dir.sa1.exists()
+    f.create()
+    assert f.to_path().is_dir()
+    # listed child under partition can be materialised
+    assert y2016_dir.to_path().is_dir()
+    assert f.get_subfolder("year=2021").to_path().exists()
+    assert not f.get_subfolder("year=2023").to_path().exists()
+    with pytest.raises(NameError):
+        f.get_partition("year=2023")
+
+
+def test_enumerated_subfolder_logical(path_not_on_disk: Path) -> None:
+    class EnumeratedAsgsLayersByYear(EnumeratedFolderPartition[AsgsYearDir]):
+        partition_prefix = "year="
+        partition_names = ("2016", "2021")
+
+    f = EnumeratedAsgsLayersByYear(path_not_on_disk)
+
+    assert type(f.get_subfolder("foo")) == Folder  # Shouldn't be AsgsYearDir, doesn't conform # noqa: E721
+    assert type(f.get_subfolder("foo", subfolder_class=AsgsYearDir)) == AsgsYearDir  # noqa: E721
+    assert type(f.get_partition("2016")) == AsgsYearDir  # noqa: E721
+
+def test_folder_partition_class_getitem_caching(path_not_on_disk: Path) -> None:
+    #FolderPartition[X] must return the same class object on repeated calls.
+    assert FolderPartition[AsgsYearDir] is FolderPartition[AsgsYearDir]
+
+    class MultiPartition(Folder):
+        parts_a: FolderPartition[AsgsYearDir]
+        parts_b: FolderPartition[AsgsYearDir]
+
+    folder = MultiPartition(path_not_on_disk)
+    assert type(folder.parts_a) is type(folder.parts_b)

--- a/test/test_folder_partition.py
+++ b/test/test_folder_partition.py
@@ -1,8 +1,9 @@
 from pathlib import Path
+
 import pytest
+from test_basic import AsgsYearDir
 
 from static_folders import EnumeratedFolderPartition, Folder, FolderPartition
-from test_basic import AsgsYearDir
 
 
 @pytest.fixture
@@ -10,8 +11,10 @@ def path_not_on_disk(tmp_path: Path) -> Path:
     # get a path which pytest isn't mkdiring
     return tmp_path / "new_dir_not_on_disk"
 
+
 class AsgsLayersByYear(FolderPartition[AsgsYearDir]):
     pass
+
 
 def test_partitioned_folder(path_not_on_disk: Path) -> None:
     f = AsgsLayersByYear(path_not_on_disk)
@@ -98,8 +101,9 @@ def test_enumerated_subfolder_logical(path_not_on_disk: Path) -> None:
     assert type(f.get_subfolder("foo", subfolder_class=AsgsYearDir)) == AsgsYearDir  # noqa: E721
     assert type(f.get_partition("2016")) == AsgsYearDir  # noqa: E721
 
+
 def test_folder_partition_class_getitem_caching(path_not_on_disk: Path) -> None:
-    #FolderPartition[X] must return the same class object on repeated calls.
+    # FolderPartition[X] must return the same class object on repeated calls.
     assert FolderPartition[AsgsYearDir] is FolderPartition[AsgsYearDir]
 
     class MultiPartition(Folder):


### PR DESCRIPTION
Closes #11 

**Bug:** Subfolder attributes given a pre-assigned `Folder` value (to use a custom
directory name) were not being anchored under the parent folder. The pre-assigned object
was kept with a bare relative path, so e.g. `photos.y2025.location` would be `Path("2025")`
rather than the correct `parent_path / "2025"`. A workaround in the existing test
(`tmp_path = Path(".")`) had been masking the failure.

**Fix:** `Folder.__attrs_post_init__` now extracts the folder name from any pre-assigned
`FolderLike` value and re-creates the subfolder anchored under the parent's location.

**Other changes:**

- **`FolderLike` → ABC** — Converted from a `runtime_checkable` Protocol to an Abstract
  Base Class with `@abstractmethod` markers and a new `from_path` classmethod, improving
  LSP / static analysis compatibility.
- **`FolderPartition` generics overhaul** — Removed `partition_class` as a constructor
  argument. `FolderPartition[SomeClass](path)` now captures the type parameter via a
  custom `__class_getitem__` that dynamically creates a typed subclass (with a
  module-level cache). No need to repeat the class at construction time.
- **Improved error messages** — Clear `TypeError` when a `FolderLike`-annotated attribute
  is assigned a `Path` value (ambiguous), and when `FolderPartition` is constructed
  without explicit generics.
- **Tests reorganised** — Partition tests moved to `test/test_folder_partition.py`. New
  tests cover custom folder name anchoring (issue #11), ambiguous annotation errors,
  partition generics validation, and `__class_getitem__` caching.
- **Tooling** — CI matrix updated to Python 3.14, `pixi.toml` changed to `[workspace]`
  key, ruff config tweaks, lock file bumped to v0.3.0.